### PR TITLE
Fix Short-circuiting, Enhance Output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/BlockLength:
     - define
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 30
 
 AllCops:
   TargetRubyVersion: 2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,9 @@ Metrics/AbcSize:
 
 Metrics/ClassLength:
   Max: 125
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.0 (May 12th, 2020)
+
+Additions:
+
+* Do not make missing fixtures short-circuit the rest of the test suite.
+* Do not make PDI timeouts short-circuit the rest of the test suite.
+* Report PDI's exit code and execution time to the console.
+
 # 2.0.0 (May 11th, 2020)
 
 Breaking Changes:

--- a/lib/simmer/database/fixture_set.rb
+++ b/lib/simmer/database/fixture_set.rb
@@ -13,6 +13,8 @@ module Simmer
   module Database
     # Hydrate a collection of Fixture instances from configuration.
     class FixtureSet
+      class FixtureMissingError < StandardError; end
+
       def initialize(config = {})
         @fixtures_by_name = config_to_fixures_by_name(config)
 
@@ -22,7 +24,7 @@ module Simmer
       def get!(name)
         key = name.to_s
 
-        raise ArgumentError, "fixture not found: #{name}" unless fixtures_by_name.key?(key)
+        raise FixtureMissingError, "fixture missing: #{name}" unless fixtures_by_name.key?(key)
 
         fixtures_by_name[key]
       end

--- a/lib/simmer/judge/result.rb
+++ b/lib/simmer/judge/result.rb
@@ -13,7 +13,7 @@ module Simmer
     class Result
       attr_reader :bad_assertions
 
-      def initialize(bad_assertions)
+      def initialize(bad_assertions = [])
         @bad_assertions = bad_assertions
 
         freeze

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -43,7 +43,7 @@ module Simmer
       ).tap do |result|
         print_result(result)
       end
-    rescue Database::FixtureSet::FixtureMissingError => e
+    rescue Database::FixtureSet::FixtureMissingError, Timeout::Error => e
       Result.new(
         id: id,
         specification: specification,

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -86,8 +86,16 @@ module Simmer
 
     def execute_spoon(specification, config)
       print_waiting('Act', 'Executing Spoon')
+
       spoon_client_result = spoon_client.run(specification, config)
-      msg = pass_message(spoon_client_result)
+      time_in_seconds     = spoon_client_result.time_in_seconds
+      code                = spoon_client_result.execution_result.status.code
+
+      msg = [
+        pass_message(spoon_client_result),
+        "(Exited with code #{code} after #{time_in_seconds} seconds)"
+      ].join(' ')
+
       print(msg)
 
       spoon_client_result

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -123,6 +123,9 @@ module Simmer
       print(msg)
 
       spoon_client_result
+    rescue Timeout::Error => e
+      print('Timed out')
+      raise e
     end
 
     def assert(specification, spoon_client_result)

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -87,6 +87,9 @@ module Simmer
       print("#{count} record(s) inserted")
 
       count
+    rescue Database::FixtureSet::FixtureMissingError => e
+      print('Missing Fixture(s)')
+      raise e
     end
 
     def clean_file_system

--- a/lib/simmer/runner/result.rb
+++ b/lib/simmer/runner/result.rb
@@ -13,23 +13,36 @@ module Simmer
     class Result
       extend Forwardable
 
-      attr_reader :id, :judge_result, :specification, :spoon_client_result
-
-      def_delegators :spoon_client_result, :time_in_seconds
+      attr_reader :errors, :id, :judge_result, :specification, :spoon_client_result
 
       def_delegators :specification, :name
 
-      def initialize(id, judge_result, specification, spoon_client_result)
+      def initialize(
+        id:,
+        specification:,
+        judge_result: nil,
+        spoon_client_result: nil,
+        errors: []
+      )
         @id                  = id.to_s
         @judge_result        = judge_result
         @specification       = specification
         @spoon_client_result = spoon_client_result
+        @errors              = Array(errors)
 
         freeze
       end
 
+      def time_in_seconds
+        spoon_client_result&.time_in_seconds || 0
+      end
+
       def pass?
-        judge_result&.pass? && spoon_client_result&.pass?
+        (
+          judge_result&.pass? &&
+            spoon_client_result&.pass? &&
+            errors.empty?
+        ) || false
       end
 
       def fail?
@@ -44,7 +57,8 @@ module Simmer
           'time_in_seconds' => time_in_seconds,
           'pass' => pass?,
           'spoon_client_result' => spoon_client_result.to_h,
-          'judge_result' => judge_result.to_h
+          'judge_result' => judge_result.to_h,
+          'errors' => errors
         }
       end
     end

--- a/lib/simmer/runner/result.rb
+++ b/lib/simmer/runner/result.rb
@@ -38,11 +38,11 @@ module Simmer
       end
 
       def pass?
-        (
-          judge_result&.pass? &&
-            spoon_client_result&.pass? &&
-            errors.empty?
-        ) || false
+        [
+          judge_result&.pass?,
+          spoon_client_result&.pass?,
+          errors.empty?,
+        ].all?
       end
 
       def fail?
@@ -58,8 +58,16 @@ module Simmer
           'pass' => pass?,
           'spoon_client_result' => spoon_client_result.to_h,
           'judge_result' => judge_result.to_h,
-          'errors' => errors
+          'errors' => errors,
         }
+      end
+
+      def execution_output
+        execution_result&.out
+      end
+
+      def execution_result
+        spoon_client_result&.execution_result
       end
     end
   end

--- a/lib/simmer/suite/reporter.rb
+++ b/lib/simmer/suite/reporter.rb
@@ -58,7 +58,7 @@ module Simmer
         runner_results.each do |runner_result|
           name         = runner_result.name
           runner_id    = runner_result.id
-          out_contents = runner_result.spoon_client_result.execution_result.out
+          out_contents = runner_result&.spoon_client_result&.execution_result&.out
 
           write_block(pdi_out_file, name, runner_id, out_contents)
         end

--- a/lib/simmer/suite/reporter.rb
+++ b/lib/simmer/suite/reporter.rb
@@ -58,7 +58,7 @@ module Simmer
         runner_results.each do |runner_result|
           name         = runner_result.name
           runner_id    = runner_result.id
-          out_contents = runner_result&.spoon_client_result&.execution_result&.out
+          out_contents = runner_result.execution_output
 
           write_block(pdi_out_file, name, runner_id, out_contents)
         end

--- a/lib/simmer/suite/result.rb
+++ b/lib/simmer/suite/result.rb
@@ -22,6 +22,7 @@ module Simmer
       def pass?
         !fail?
       end
+      alias passing? pass?
 
       def fail?
         runner_results.any?(&:fail?)

--- a/lib/simmer/version.rb
+++ b/lib/simmer/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Simmer
-  VERSION = '2.1.0'
+  VERSION = '2.1.0-alpha'
 end

--- a/lib/simmer/version.rb
+++ b/lib/simmer/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Simmer
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/fixtures/specifications/missing_fixtures.yaml
+++ b/spec/fixtures/specifications/missing_fixtures.yaml
@@ -1,0 +1,10 @@
+name: I am purposefully missing fixtures
+stage:
+  fixtures:
+    - i_do_not_exist
+act:
+  name: does_not_matter
+  repository: does_not_matter
+  type: transformation
+assert:
+  assertions:

--- a/spec/mocks/spoon/kitchen.sh
+++ b/spec/mocks/spoon/kitchen.sh
@@ -8,6 +8,8 @@ output(){
   echo "$1"
 }
 
+sleep $2
+
 output "output to stdout"
 error "output to sterr"
 

--- a/spec/mocks/spoon/pan.sh
+++ b/spec/mocks/spoon/pan.sh
@@ -8,6 +8,8 @@ output(){
   echo "$1"
 }
 
+sleep $2
+
 output "output to stdout"
 error "output to sterr"
 

--- a/spec/simmer/database/fixture_set_spec.rb
+++ b/spec/simmer/database/fixture_set_spec.rb
@@ -47,8 +47,10 @@ describe Simmer::Database::FixtureSet do
         expect(subject.get!(name)).to eq(expected)
       end
 
-      it 'raises ArgumentError if name does not exist' do
-        expect { subject.get!(:doesnt_exist) }.to raise_error(ArgumentError)
+      it 'raises FixtureMissingError if name does not exist' do
+        err = described_class::FixtureMissingError
+
+        expect { subject.get!(:doesnt_exist) }.to raise_error(err)
       end
     end
 
@@ -67,8 +69,10 @@ describe Simmer::Database::FixtureSet do
         expect(subject.get!(name)).to eq(expected)
       end
 
-      it 'raises ArgumentError if name does not exist' do
-        expect { subject.get!(:doesnt_exist) }.to raise_error(ArgumentError)
+      it 'raises FixtureMissingError if name does not exist' do
+        err = described_class::FixtureMissingError
+
+        expect { subject.get!(:doesnt_exist) }.to raise_error(err)
       end
     end
   end

--- a/spec/simmer/runner/result_spec.rb
+++ b/spec/simmer/runner/result_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe Simmer::Runner::Result do
+  let(:path)                 { File.join('specifications', 'load_noc_list.yaml') }
+  let(:spec_config)          { yaml_fixture(path).merge(path: path) }
+  let(:specification)        { Simmer::Specification.make(spec_config) }
+  let(:id)                   { '123' }
+  let(:passing_judge_result) { Simmer::Judge::Result.new }
+
+  let(:passing_execution_result) do
+    Pdi::Executor::Result.make(
+      args: [],
+      status: {
+        code: 0,
+        pid: 123
+      }
+    )
+  end
+
+  let(:passing_spoon_client_result) do
+    Simmer::Externals::SpoonClient::Result.new(
+      execution_result: passing_execution_result,
+      time_in_seconds: 0
+    )
+  end
+
+  describe '#pass?' do
+    it 'is false if at least one error is present' do
+      subject = described_class.new(
+        id: id,
+        specification: specification,
+        errors: 'Some Error'
+      )
+
+      expect(subject.pass?).to be false
+    end
+
+    it 'is true if judge passes, spoon passes, and no errors are present' do
+      subject = described_class.new(
+        id: id,
+        specification: specification,
+        judge_result: passing_judge_result,
+        spoon_client_result: passing_spoon_client_result
+      )
+
+      expect(subject.pass?).to be true
+    end
+  end
+end

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -126,4 +126,38 @@ describe Simmer do
       end
     end
   end
+
+  context 'when the fixtures are missing' do
+    let(:spec_path)   { File.join('spec', 'fixtures', 'specifications', 'missing_fixtures.yaml') }
+    let(:simmer_dir)  { File.join('spec', 'simmer_spec') }
+    let(:out)         { Out.new }
+    let(:config_path) { stage_simmer_config(spoon_path, args) }
+
+    context 'when pdi does not do anything but does not fail' do
+      let(:spoon_path)  { File.join('spec', 'mocks', 'spoon') }
+      let(:args)        { 0 }
+
+      it 'fails' do
+        results = described_class.run(
+          spec_path,
+          config_path: config_path,
+          out: out,
+          simmer_dir: simmer_dir
+        )
+
+        expect(results.pass?).to be false
+      end
+
+      it 'records error' do
+        results = described_class.run(
+          spec_path,
+          config_path: config_path,
+          out: out,
+          simmer_dir: simmer_dir
+        )
+
+        expect(results.runner_results.first.errors).to include(/fixture missing/)
+      end
+    end
+  end
 end

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -54,7 +54,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be false
+        expect(results).not_to be_passing
       end
     end
 
@@ -70,7 +70,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be false
+        expect(results).not_to be_passing
       end
     end
 
@@ -86,7 +86,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be true
+        expect(results).to be_passing
       end
     end
 
@@ -102,7 +102,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be false
+        expect(results).not_to be_passing
       end
     end
 
@@ -119,7 +119,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be false
+        expect(results).not_to be_passing
       end
 
       it 'records error' do
@@ -175,7 +175,7 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.pass?).to be false
+        expect(results).not_to be_passing
       end
 
       it 'records error' do


### PR DESCRIPTION
I put this library up against our production PDI transformation repository and found a few things lacking and/or annoying.  This PR adds three basic enhancements:

1. Do not make missing fixtures short-circuit the rest of the test suite

![image](https://user-images.githubusercontent.com/906763/81721899-37064200-9446-11ea-9712-80015fb9532e.png)

2. Do not make PDI timeouts short-circuit the rest of the test suite

![image](https://user-images.githubusercontent.com/906763/81722086-83518200-9446-11ea-85d2-7fd7122decb8.png)

3. Report PDI's exit code and execution time to the console

![image](https://user-images.githubusercontent.com/906763/81721439-797b4f00-9445-11ea-87fe-17243758fd20.png)


