### PR TITLE
Mysql reserved words fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Additions:
 
 * pdi_out.txt is written to throughout test execution instead of at the end.
 
+Fixes:
+
+* Seeds now handle identifiers which are MySQL reserved words.
+
 ## 2.1.0 (May 13th, 2020)
 
 Additions:

--- a/lib/simmer/externals/mysql_database.rb
+++ b/lib/simmer/externals/mysql_database.rb
@@ -27,7 +27,7 @@ module Simmer
       end
 
       def records(table, columns = [])
-        query = "SELECT #{sql_select_params(columns)} FROM #{table}"
+        query = "SELECT #{sql_select_params(columns)} FROM `#{table}`"
 
         client.query(query).to_a
       end
@@ -53,7 +53,7 @@ module Simmer
       attr_reader :client, :fixture_set, :table_names
 
       def sql_select_params(columns)
-        Array(columns).any? ? Array(columns).map { |c| client.escape(c) }.join(',') : '*'
+        Array(columns).any? ? Array(columns).map { |c| "`#{client.escape(c)}`" }.join(',') : '*'
       end
 
       def seed_sql_statements(fixtures)
@@ -62,7 +62,7 @@ module Simmer
 
       def clean_sql_statements
         table_names.map do |table_name|
-          "TRUNCATE #{table_name}"
+          "TRUNCATE `#{table_name}`"
         end
       end
 

--- a/spec/db/tables.sql
+++ b/spec/db/tables.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS `agents`;
+DROP TABLE IF EXISTS `simmer_test`.`agents`;
 
-CREATE TABLE `agents` (
+CREATE TABLE `simmer_test`.`agents` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `call_sign` varchar(150) NOT NULL,
   `first` varchar(255) DEFAULT NULL,
@@ -9,9 +9,9 @@ CREATE TABLE `agents` (
   UNIQUE KEY `call_sign` (`call_sign`)
 ) ENGINE = InnoDB AUTO_INCREMENT = 3 DEFAULT CHARSET = utf8mb4;
 
-DROP TABLE IF EXISTS `notes`;
+DROP TABLE IF EXISTS `simmer_test`.`notes`;
 
-CREATE TABLE `notes` (
+CREATE TABLE `simmer_test`.`notes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `agent_id` int(11) NOT NULL,
   `note` varchar(255) DEFAULT NULL,
@@ -20,9 +20,9 @@ CREATE TABLE `notes` (
   CONSTRAINT `notes_ibfk_1` FOREIGN KEY (`agent_id`) REFERENCES `agents` (`id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
-DROP TABLE IF EXISTS `table`;
+DROP TABLE IF EXISTS `simmer_test`.`table`;
 
-CREATE TABLE `table` (
+CREATE TABLE `simmer_test`.`table` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `column` varchar(30) NOT NULL,
   `count` int(11) NOT NULL,

--- a/spec/db/tables.sql
+++ b/spec/db/tables.sql
@@ -1,20 +1,31 @@
-DROP TABLE IF EXISTS `simmer_test`.`notes`;
-DROP TABLE IF EXISTS `simmer_test`.`agents`;
+DROP TABLE IF EXISTS `agents`;
 
-CREATE TABLE `simmer_test`.`agents` (
+CREATE TABLE `agents` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `call_sign` varchar(150) NOT NULL,
-  `first` varchar(255),
-  `last` varchar(255),
+  `first` varchar(255) DEFAULT NULL,
+  `last` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE INDEX (`call_sign`)
-);
+  UNIQUE KEY `call_sign` (`call_sign`)
+) ENGINE = InnoDB AUTO_INCREMENT = 3 DEFAULT CHARSET = utf8mb4;
 
-CREATE TABLE `simmer_test`.`notes` (
+DROP TABLE IF EXISTS `notes`;
+
+CREATE TABLE `notes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `agent_id` int(11) NOT NULL,
-  `note` varchar(255),
+  `note` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  INDEX (`agent_id`),
-  FOREIGN KEY (`agent_id`) REFERENCES `simmer_test`.`agents`(`id`)
-);
+  KEY `agent_id` (`agent_id`),
+  CONSTRAINT `notes_ibfk_1` FOREIGN KEY (`agent_id`) REFERENCES `agents` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+DROP TABLE IF EXISTS `table`;
+
+CREATE TABLE `table` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `column` varchar(30) NOT NULL,
+  `count` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`)
+) ENGINE = InnoDB AUTO_INCREMENT = 3 DEFAULT CHARSET = utf8mb4;

--- a/spec/db_helper.rb
+++ b/spec/db_helper.rb
@@ -9,7 +9,8 @@
 
 CLEAN_SQL_STATEMENTS = [
   'DELETE FROM `simmer_test`.`notes`',
-  'DELETE FROM `simmer_test`.`agents`'
+  'DELETE FROM `simmer_test`.`agents`',
+  'DELETE FROM `simmer_test`.`table`'
 ].freeze
 
 def db_helper_config

--- a/spec/fixtures/agent_fixtures.yaml
+++ b/spec/fixtures/agent_fixtures.yaml
@@ -12,3 +12,14 @@ iron_man:
     first: CLASSIFIED
     last: CLASSIFIED
 
+reserved1:
+  table: table
+  fields:
+    column: reserved1
+    count: 1
+
+reserved2:
+  table: table
+  fields:
+    column: reserved2
+    count: 2

--- a/spec/fixtures/specifications/handle_mysql_reserved_words.yaml
+++ b/spec/fixtures/specifications/handle_mysql_reserved_words.yaml
@@ -1,0 +1,26 @@
+name: Handle MySQL Reserved Words
+stage:
+  files:
+    src: noc_list.csv
+    dest: input/noc_list.csv
+  fixtures:
+    - reserved1
+    - reserved2
+act:
+  name: load_noc_list
+  repository: top_secret
+  type: transformation
+assert:
+  assertions:
+    - type: table
+      name: table
+      records:
+        - column: reserved1
+          count: 1
+        - column: reserved2
+          count: 1
+    - type: table
+      name: table
+      logic: includes
+      records:
+        - column: reserved1


### PR DESCRIPTION
This fixes an issue with fixtures where tables could not contain identifiers which were MySQL reserved words. This is intended to be released along with the streaming-output branch but I wanted to break up the PR's to keep them focused.