### PR TITLE
Lifecycle hooks and auto retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Additions:
 Breaking Changes:
 
 * The `callback_configuration` and `make_runner` methods have been removed from the `Simmer` module.
-
+* `Simmer::Runner::Result#errors` now contains error/exception instances instead of strings.
 
 ## 3.0.0 (June 8th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Simmer Change Log
 
-## 3.1.0 (TBD, 2020)
+## 4.0.0 (TBD, 2020)
+
+Additions:
 
 * Support for custom test lifecycle hooks to be run before and after a every test or the entire suite.
+* Simmer can now be configured to re-run tests which have failed due to a timeout a custom number of times.
+
+Breaking Changes:
+
+* The `callback_configuration` and `make_runner` methods have been removed from the `Simmer` module.
+
 
 ## 3.0.0 (June 8th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Simmer Change Log
 
+## 3.1.0 (TBD, 2020)
+
+* Support for custom test lifecycle hooks to be run before and after a every test or the entire suite.
+
 ## 3.0.0 (June 8th, 2020)
 
 Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking Changes:
 
 * The `callback_configuration` and `make_runner` methods have been removed from the `Simmer` module.
 * `Simmer::Runner::Result#errors` now contains error/exception instances instead of strings.
+* `Simmer::Suite.new` and `Simmer::Runner.run` now takes a `Simmer::Configuration` instance instead of a hash of configuration values.
+* The config keyword parameter of `Simmer::Runner.run` is now mandatory.
 
 ## 3.0.0 (June 8th, 2020)
 

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ bundle exec simmer
 It is possible to define custom test lifecycle hooks. These are very similar to [Rspec](https://relishapp.com/rspec/rspec-core/v/3-9/docs/hooks/before-and-after-hooks). Here is an example of how to ensure that code called before and after the entire suite:
 
 ````ruby
-Simmer.configure do
-  before(:suite) { puts 'about to run the entire suite' }
-  after(:suite) do |result|
+Simmer.configure do |config|
+  config.before(:suite) { puts 'about to run the entire suite' }
+  config.after(:suite) do |result|
     result_msg = result.passed? ? 'passed' : 'failed'
     puts "The suite #{result_msg}."
   end
@@ -292,9 +292,9 @@ Not that after callbacks taken an optional parameter which is the result object.
 It is also possible to specify custom code which runs before and after each individual specification.
 
 ````ruby
-Simmer.configure do
-  before(:each) { puts 'I will run before each test' }
-  after(:each) do |result|
+Simmer.configure do |config|
+  config.before(:each) { puts 'I will run before each test' }
+  config.after(:each) do |result|
     result_msg = result.passed? ? 'passed' : 'failed'
     puts "The specification #{result_msg}."
   end

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ The configuration file contains information about external systems, such as:
 Copy this configuration template into your project's root to: `config/simmer.yaml`:
 
 ````yaml
+# Automatically retry a test when it has failed this many times due to a timeout error:
+timeout_failure_retry_count: 0
+
 mysql_database:
   database:
   username:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,34 @@ You can also omit the path altogether to execute all specs:
 bundle exec simmer
 ````
 
+## Custom Configuration
+
+It is possible to define custom test lifecycle hooks. These are very similar to [Rspec](https://relishapp.com/rspec/rspec-core/v/3-9/docs/hooks/before-and-after-hooks). Here is an example of how to ensure that code called before and after the entire suite:
+
+````ruby
+Simmer.configure do
+  before(:suite) { puts 'about to run the entire suite' }
+  after(:suite) do |result|
+    result_msg = result.passed? ? 'passed' : 'failed'
+    puts "The suite #{result_msg}."
+  end
+end
+````
+
+Not that after callbacks taken an optional parameter which is the result object.
+
+It is also possible to specify custom code which runs before and after each individual specification.
+
+````ruby
+Simmer.configure do
+  before(:each) { puts 'I will run before each test' }
+  after(:each) do |result|
+    result_msg = result.passed? ? 'passed' : 'failed'
+    puts "The specification #{result_msg}."
+  end
+end
+````
+
 ## Contributing
 
 ### Development Environment Configuration

--- a/lib/simmer.rb
+++ b/lib/simmer.rb
@@ -58,13 +58,13 @@ module Simmer
       suite.run(specs)
     end
 
-    def make_configuration(
-      config_path: DEFAULT_CONFIG_PATH,
-      simmer_dir: DEFAULT_SIMMER_DIR
-    )
+    def make_configuration(config_path: DEFAULT_CONFIG_PATH, simmer_dir: DEFAULT_SIMMER_DIR)
       raw_config = yaml_reader.smash(config_path)
+      Configuration.new(raw_config, simmer_dir, callbacks: callback_configuration)
+    end
 
-      Configuration.new(raw_config, simmer_dir)
+    def callback_configuration
+      @callback_configuration ||= Configuration::CallbackDsl.new
     end
 
     def make_runner(configuration, out_router)
@@ -80,6 +80,18 @@ module Simmer
         out: out_router,
         spoon_client: spoon_client
       )
+    end
+
+    def configure(&block)
+      # TODO: support the arity 1 case
+      # if block_given?
+      #   if block.arity == 1
+      #     yield self
+      #   else
+      #     instance_eval &block
+      #   end
+      # end
+      callback_configuration.instance_eval(&block)
     end
 
     private
@@ -151,7 +163,7 @@ module Simmer
 
     def make_suite(configuration, out, runner)
       Suite.new(
-        config: configuration.config,
+        config: configuration,
         out: out,
         results_dir: configuration.results_dir,
         runner: runner

--- a/lib/simmer.rb
+++ b/lib/simmer.rb
@@ -34,11 +34,16 @@ require_relative 'simmer/configuration'
 require_relative 'simmer/database'
 require_relative 'simmer/externals'
 require_relative 'simmer/runner'
+require_relative 'simmer/re_runner'
 require_relative 'simmer/specification'
 require_relative 'simmer/suite'
 
 # The main entry-point API for the library.
+
+# TODO: split this up and re-enable this cop:
+# rubocop:disable Metrics/ModuleLength
 module Simmer
+  # rubocop:enable Metrics/ModuleLength
   DEFAULT_CONFIG_PATH = File.join('config', 'simmer.yaml').freeze
   DEFAULT_SIMMER_DIR  = 'simmer'
 
@@ -73,12 +78,18 @@ module Simmer
       fixture_set  = make_fixture_set(configuration)
       spoon_client = make_spoon_client(configuration)
 
-      Runner.new(
+      runner = Runner.new(
         database: database,
         file_system: file_system,
         fixture_set: fixture_set,
         out: out_router,
         spoon_client: spoon_client
+      )
+
+      ReRunner.new(
+        runner,
+        out_router,
+        timeout_failure_retry_count: configuration.timeout_failure_retry_count
       )
     end
 

--- a/lib/simmer.rb
+++ b/lib/simmer.rb
@@ -65,16 +65,8 @@ module Simmer
     end
     alias make_configuration configuration
 
-    def configure(&block)
-      # TODO: support the arity 1 case
-      # if block_given?
-      #   if block.arity == 1
-      #     yield self
-      #   else
-      #     instance_eval &block
-      #   end
-      # end
-      callback_configuration.instance_eval(&block)
+    def configure
+      yield callback_configuration
     end
 
     private

--- a/lib/simmer/bootstrap.rb
+++ b/lib/simmer/bootstrap.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Simmer
+  # :nodoc:
+  # Responsible for creating core objects needed to run tests.
+  class Bootstrap
+    attr_reader :callback_configuration, :configuration, :console_out, :spec_path
+
+    def initialize(
+      config_path:,
+      simmer_dir:,
+      spec_path: nil,
+      console_out: $stdout,
+      callback_configuration: Configuration::CallbackDsl.new
+    )
+      @spec_path = spec_path.to_s
+      raw_config = yaml_reader.smash(config_path)
+      @configuration = Configuration.new(raw_config, simmer_dir, callbacks: callback_configuration)
+      @console_out = console_out
+      @callback_configuration = callback_configuration
+
+      freeze
+    end
+
+    def run_suite
+      suite.run(specs)
+    end
+
+    private
+
+    def specs
+      path = spec_path.empty? ? configuration.tests_dir : spec_path
+
+      Util::YamlReader.new.read(path).map do |file|
+        config = (file.data || {}).merge(path: file.path)
+
+        Specification.make(config)
+      end
+    end
+
+    def suite
+      Suite.new(
+        config: configuration,
+        out: console_out,
+        results_dir: configuration.results_dir,
+        runner: runner
+      )
+    end
+
+    def runner
+      runner = Runner.new(
+        database: mysql_database,
+        file_system: file_system,
+        fixture_set: fixture_set,
+        out: output_router,
+        spoon_client: spoon_client
+      )
+
+      ReRunner.new(
+        runner,
+        output_router,
+        timeout_failure_retry_count: configuration.timeout_failure_retry_count
+      )
+    end
+
+    def yaml_reader
+      Util::YamlReader.new
+    end
+
+    def fixture_set
+      config = Util::YamlReader.new.smash(configuration.fixtures_dir)
+
+      Database::FixtureSet.new(config)
+    end
+
+    def mysql_database
+      config         = configuration.mysql_database_config.symbolize_keys
+      client         = Mysql2::Client.new(config)
+      exclude_tables = config[:exclude_tables]
+
+      Externals::MysqlDatabase.new(client, exclude_tables)
+    end
+
+    def file_system
+      if configuration.aws_file_system?
+        aws_file_system
+      elsif configuration.local_file_system?
+        local_file_system
+      else
+        raise ArgumentError, 'cannot determine file system'
+      end
+    end
+
+    def aws_file_system
+      config      = configuration.aws_file_system_config.symbolize_keys
+      client_args = config.slice(:access_key_id, :secret_access_key, :region)
+      client      = Aws::S3::Client.new(client_args)
+
+      Externals::AwsFileSystem.new(
+        client,
+        config[:bucket],
+        config[:encryption],
+        configuration.files_dir
+      )
+    end
+
+    def local_file_system
+      config = configuration.local_file_system_config.symbolize_keys
+
+      Externals::LocalFileSystem.new(config[:dir], configuration.files_dir)
+    end
+
+    def spoon_client
+      config     = (configuration.spoon_client_config || {}).symbolize_keys
+      spoon_args = config.slice(:args, :dir, :kitchen, :pan, :timeout_in_seconds)
+      spoon      = Pdi::Spoon.new(spoon_args)
+
+      Externals::SpoonClient.new(configuration.files_dir, spoon)
+    end
+
+    def output_router
+      pdi_out = Suite::PdiOutputWriter.new(configuration.results_dir)
+      Simmer::Suite::OutputRouter.new(console_out, pdi_out)
+    end
+  end
+end

--- a/lib/simmer/configuration.rb
+++ b/lib/simmer/configuration.rb
@@ -7,10 +7,14 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+require_relative 'configuration/callback_dsl'
+
 module Simmer
   # Reads in the Simmer configuration file and options and provides it to the rest of the
   # Simmer implementation.
   class Configuration
+    extend Forwardable
+
     # Configuration Keys
     AWS_FILE_SYSTEM_KEY   = :aws_file_system
     LOCAL_FILE_SYSTEM_KEY = :local_file_system
@@ -32,10 +36,14 @@ module Simmer
 
     attr_reader :config
 
-    def initialize(config, simmer_dir, resolver: Objectable.resolver)
+    # :nodoc:
+    def_delegators :callbacks, :run_single_test_with_callbacks, :run_suite_with_callbacks
+
+    def initialize(config, simmer_dir, resolver: Objectable.resolver, callbacks: nil)
       @config      = config || {}
       @resolver    = resolver
       @simmer_dir  = simmer_dir
+      @callbacks   = callbacks
 
       freeze
     end
@@ -82,7 +90,8 @@ module Simmer
 
     private
 
-    attr_reader :resolver,
+    attr_reader :callbacks,
+                :resolver,
                 :simmer_dir,
                 :yaml_reader
 

--- a/lib/simmer/configuration.rb
+++ b/lib/simmer/configuration.rb
@@ -19,6 +19,7 @@ module Simmer
     AWS_FILE_SYSTEM_KEY   = :aws_file_system
     LOCAL_FILE_SYSTEM_KEY = :local_file_system
     MYSQL_DATABASE_KEY    = :mysql_database
+    TIMEOUT_RETRY_KEY     = :timeout_failure_retry_count
     SPOON_CLIENT_KEY      = :spoon_client
 
     # Paths
@@ -66,6 +67,10 @@ module Simmer
 
     def local_file_system?
       config.key?(LOCAL_FILE_SYSTEM_KEY.to_s)
+    end
+
+    def timeout_failure_retry_count
+      get(TIMEOUT_RETRY_KEY) || 0
     end
 
     def spoon_client_config

--- a/lib/simmer/configuration/callback_dsl.rb
+++ b/lib/simmer/configuration/callback_dsl.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Simmer
+  class Configuration
+    # Defines lifecycle hooks which can be run before and after the entire
+    # suite or just a single test. Very similar to Rspec
+    # (https://relishapp.com/rspec/rspec-core/v/3-9/docs/hooks/before-and-after-hooks).
+    class CallbackDsl
+      def initialize
+        @before_suite = []
+        @after_suite = []
+        @before_each = []
+        @after_each = []
+
+        freeze
+      end
+
+      # Used to create a before callback. This accepts and optional level
+      # parameter which can either be :suite or :each. ":each" is implied if no
+      # level is provided.
+      def before(level = LEVEL_EACH, &block)
+        verify_level!(level)
+
+        level == LEVEL_SUITE ? before_suite.push(block) : before_each.push(block)
+      end
+
+      # Used to create an after callback. This accepts and optional level
+      # parameter which can either be :suite or :each. ":each" is implied if no
+      # level is provided.
+      def after(level = LEVEL_EACH, &block)
+        verify_level!(level)
+
+        level == LEVEL_SUITE ? after_suite.push(block) : after_each.push(block)
+      end
+
+      # :nodoc:
+      def run_single_test_with_callbacks
+        before_each.each(&:call)
+
+        result = yield
+
+        after_each.each { |block| block.call(result) }
+
+        result
+      end
+
+      # :nodoc:
+      def run_suite_with_callbacks
+        before_suite.each(&:call)
+
+        result = yield
+
+        after_suite.each { |block| block.call(result) }
+
+        result
+      end
+
+      private
+
+      def verify_level!(level)
+        raise ArgumentError, "unknown test level: #{level}" unless CALLBACK_LEVELS.include?(level)
+      end
+
+      attr_reader :after_each, :before_each, :after_suite, :before_suite
+
+      LEVEL_EACH = :each
+      LEVEL_SUITE = :suite
+      CALLBACK_LEVELS = Set.new([LEVEL_EACH, LEVEL_SUITE])
+      private_constant :LEVEL_EACH, :LEVEL_SUITE, :CALLBACK_LEVELS
+    end
+  end
+end

--- a/lib/simmer/re_runner.rb
+++ b/lib/simmer/re_runner.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'judge'
+require_relative 'runner/result'
+
+module Simmer
+  # :nodoc:
+  # Wraps a <tt>Simmer::Runner</tt> and knows how to re-run tests based
+  # on certain failure cases.
+  class ReRunner < SimpleDelegator
+    attr_reader :timeout_failure_retry_count
+
+    def initialize(runner, out, timeout_failure_retry_count: 0)
+      @timeout_failure_retry_count = timeout_failure_retry_count.to_i
+      @out = out
+
+      super(runner)
+    end
+
+    def run(*args)
+      rerun_on_timeout(args, timeout_failure_retry_count)
+    end
+
+    private
+
+    attr_reader :out
+
+    def rerun_on_timeout(run_args, times)
+      result = __getobj__.run(*run_args)
+
+      if result.timed_out? && times.positive?
+        out.puts('Retrying due to a timeout...')
+        rerun_on_timeout(run_args, times - 1)
+      else
+        result
+      end
+    end
+  end
+end

--- a/lib/simmer/re_runner.rb
+++ b/lib/simmer/re_runner.rb
@@ -36,7 +36,7 @@ module Simmer
       result = __getobj__.run(*run_args)
 
       if result.timed_out? && times.positive?
-        out.puts('Retrying due to a timeout...')
+        out.console_puts('Retrying due to a timeout...')
         rerun_on_timeout(run_args, times - 1)
       else
         result

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -9,6 +9,7 @@
 
 require_relative 'judge'
 require_relative 'runner/result'
+require_relative 'runner/timeout_error'
 
 module Simmer
   # Runs a single specification.
@@ -41,8 +42,7 @@ module Simmer
           specification: specification,
           spoon_client_result: spoon_client_result
         ).tap { |result| out.final_verdict(result) }
-      rescue Database::FixtureSet::FixtureMissingError, Timeout::Error => e
-        # TODO: wrap Timeout::Error
+      rescue Database::FixtureSet::FixtureMissingError, Simmer::Runner::TimeoutError => e
         Result.new(id: id, specification: specification, errors: e)
               .tap { |result| out.final_verdict(result) }
       end
@@ -114,7 +114,7 @@ module Simmer
       spoon_client_result
     rescue Timeout::Error => e
       out.console_puts('Timed out')
-      raise e
+      raise Simmer::Runner::TimeoutError, e
     end
 
     def assert(specification, spoon_client_result)

--- a/lib/simmer/runner.rb
+++ b/lib/simmer/runner.rb
@@ -42,7 +42,8 @@ module Simmer
           spoon_client_result: spoon_client_result
         ).tap { |result| out.final_verdict(result) }
       rescue Database::FixtureSet::FixtureMissingError, Timeout::Error => e
-        Result.new(id: id, specification: specification, errors: e.message)
+        # TODO: wrap Timeout::Error
+        Result.new(id: id, specification: specification, errors: e)
               .tap { |result| out.final_verdict(result) }
       end
     end

--- a/lib/simmer/runner/result.rb
+++ b/lib/simmer/runner/result.rb
@@ -51,7 +51,7 @@ module Simmer
       end
 
       def timed_out?
-        errors.any? { |e| e.is_a?(Timeout::Error) }
+        errors.any? { |e| e.is_a?(Simmer::Runner::TimeoutError) }
       end
 
       def to_h

--- a/lib/simmer/runner/result.rb
+++ b/lib/simmer/runner/result.rb
@@ -44,6 +44,7 @@ module Simmer
           errors.empty?,
         ].all?
       end
+      alias passing? pass?
 
       def fail?
         !pass?

--- a/lib/simmer/runner/result.rb
+++ b/lib/simmer/runner/result.rb
@@ -50,6 +50,10 @@ module Simmer
         !pass?
       end
 
+      def timed_out?
+        errors.any? { |e| e.is_a?(Timeout::Error) }
+      end
+
       def to_h
         {
           'name' => specification.name,
@@ -59,7 +63,7 @@ module Simmer
           'pass' => pass?,
           'spoon_client_result' => spoon_client_result.to_h,
           'judge_result' => judge_result.to_h,
-          'errors' => errors,
+          'errors' => errors.map(&:message),
         }
       end
     end

--- a/lib/simmer/runner/timeout_error.rb
+++ b/lib/simmer/runner/timeout_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Simmer
+  class Runner
+    # This error used when a specification times out. It is stored in
+    # <tt>Simmer::Runner::Results#errors</tt> when a specification times out.
+    class TimeoutError < RuntimeError
+      def message
+        cause ? cause.message : DEFAULT_MESSAGE
+      end
+
+      DEFAULT_MESSAGE = 'a timeout occurred'
+      private_constant :DEFAULT_MESSAGE
+    end
+  end
+end

--- a/lib/simmer/suite.rb
+++ b/lib/simmer/suite.rb
@@ -24,7 +24,7 @@ module Simmer
       results_dir:,
       runner:
     )
-      @config      = config || {}
+      @config      = config
       @out         = out
       @resolver    = resolver
       @results_dir = results_dir
@@ -34,15 +34,17 @@ module Simmer
     end
 
     def run(specifications)
-      runner_results = run_all_specs(specifications)
-      runner.complete
+      config.run_suite_with_callbacks do
+        runner_results = run_all_specs(specifications)
+        runner.complete
 
-      Result.new(runner_results).tap do |result|
-        output_summary(result.pass?)
+        Result.new(runner_results).tap do |result|
+          output_summary(result.pass?)
 
-        ResulstWriter.new(result, results_dir).write!
+          ResulstWriter.new(result, results_dir).write!
 
-        out.puts("Results can be viewed at #{results_dir}")
+          out.puts("Results can be viewed at #{results_dir}")
+        end
       end
     end
 

--- a/lib/simmer/version.rb
+++ b/lib/simmer/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Simmer
-  VERSION = '3.0.0'
+  VERSION = '4.0.0'
 end

--- a/simmer.gemspec
+++ b/simmer.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~>0.79.0')
   s.add_development_dependency('simplecov', '~>0.17.0')
   s.add_development_dependency('simplecov-console', '~>0.6.0')
+  s.add_development_dependency('terminal-notifier-guard')
 end

--- a/spec/bootstrap_spec.rb
+++ b/spec/bootstrap_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+require './spec/mocks/out'
+
+describe Simmer::Bootstrap do
+  let(:simmer_dir)  { File.join('spec', 'simmer_spec') }
+  let(:spec_path)   { File.join('spec', 'fixtures', 'specifications', 'load_noc_list.yaml') }
+  let(:subject) do
+    described_class.new(config_path: config_path, simmer_dir: simmer_dir, spec_path: spec_path)
+  end
+
+  before do
+    # Required mocking so that '#run_suite' does not error out.
+    allow(Mysql2::Client).to receive(:new)
+    allow(Simmer::Externals::MysqlDatabase).to receive(:new).and_return(
+      double(Simmer::Externals::MysqlDatabase)
+    )
+    allow(Pdi::Spoon).to receive(:new).and_return(double(Pdi::Spoon))
+    suite_double = double(Simmer::Suite)
+    allow(Simmer::Suite).to receive(:new).and_return(suite_double)
+    allow(suite_double).to receive(:run)
+  end
+
+  describe 'when using the AWS file system' do
+    let(:config_path) { File.join('spec', 'config', 'simmer_aws.yaml') }
+    let(:aws_config) { yaml_read(config_path)['aws_file_system'].symbolize_keys }
+    let(:s3_client_double) { double(Aws::S3::Client) }
+
+    it 'creates a new S3 client and AwsFileSystem' do
+      expect(Aws::S3::Client).to receive(:new).with(
+        access_key_id: aws_config[:access_key_id],
+        secret_access_key: aws_config[:secret_access_key],
+        region: aws_config[:region]
+      ).and_return(s3_client_double)
+
+      expect(Simmer::Externals::AwsFileSystem).to receive(:new).with(
+        s3_client_double,
+        aws_config[:bucket],
+        aws_config[:encryption],
+        File.join(simmer_dir, 'files')
+      )
+
+      subject.run_suite
+    end
+  end
+
+  describe 'when the file system is not specified' do
+    let(:config_path) { File.join('spec', 'config', 'simmer_blank.yaml') }
+
+    it 'raises an error' do
+      expect { subject.run_suite }.to raise_error 'cannot determine file system'
+    end
+  end
+end

--- a/spec/config/simmer_aws.yaml
+++ b/spec/config/simmer_aws.yaml
@@ -1,0 +1,9 @@
+# This is used by the simmer_bootstrap_spec.rb to test the AWS codepaths.
+
+aws_file_system:
+  access_key_id: test_access_key
+  bucket: bucket-test
+  default_expires_in_seconds: 3600
+  encryption: test_encryption
+  region: test_region
+  secret_access_key: test_secret_key

--- a/spec/config/simmer_blank.yaml
+++ b/spec/config/simmer_blank.yaml
@@ -1,0 +1,1 @@
+# This is used by the simmer_bootstrap_spec.rb to test error handling.

--- a/spec/db_helper.rb
+++ b/spec/db_helper.rb
@@ -6,6 +6,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 #
+require 'mysql2'
+require_relative 'yaml_config_helpers'
 
 CLEAN_SQL_STATEMENTS = [
   'DELETE FROM `simmer_test`.`notes`',

--- a/spec/mocks/load_noc_list/pan.sh
+++ b/spec/mocks/load_noc_list/pan.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require './spec/spec_helper'
 require './spec/db_helper'
 
 puts 'output to stdout'

--- a/spec/mocks/load_noc_list_bad_output/pan.sh
+++ b/spec/mocks/load_noc_list_bad_output/pan.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require './spec/spec_helper'
 require './spec/db_helper'
 
 puts 'bad output!'

--- a/spec/simmer/configuration/callback_dsl_spec.rb
+++ b/spec/simmer/configuration/callback_dsl_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe Simmer::Configuration::CallbackDsl do
+  let(:subject) { described_class.new }
+
+  describe 'running a single test with callbacks' do
+    it 'runs and after callbacks in order of definition and returns the result of the block' do
+      found_order = []
+
+      subject.before { found_order.push(:first) }
+      subject.before { found_order.push(:second) }
+
+      subject.after { found_order.push(:third) }
+      subject.after { found_order.push(:fourth) }
+
+      expect(subject.run_single_test_with_callbacks { 42 }).to eq 42
+
+      expect(found_order).to eq %i[first second third fourth]
+    end
+
+    it 'passes the return value of the test to after blocks' do
+      found_return_value = nil
+      subject.after { |return_value| found_return_value = return_value }
+
+      subject.run_single_test_with_callbacks { :fake_test_result }
+
+      expect(found_return_value).to eq :fake_test_result
+    end
+
+    it 'can be called with the ":each" level' do
+      was_called = false
+      subject.before(:each) { was_called = true }
+
+      subject.run_single_test_with_callbacks {}
+
+      expect(was_called).to eq true
+    end
+  end
+
+  describe 'running a suite with callbacks' do
+    it 'runs and after callbacks in order of definition and returns the result of the block' do
+      found_order = []
+
+      subject.before(:suite) { found_order.push(:first) }
+      subject.before(:suite) { found_order.push(:second) }
+
+      subject.after(:suite) { found_order.push(:third) }
+      subject.after(:suite) { found_order.push(:fourth) }
+
+      expect(subject.run_suite_with_callbacks { 42 }).to eq 42
+
+      expect(found_order).to eq %i[first second third fourth]
+    end
+
+    it 'passes the return value of the suite to after blocks' do
+      found_return_value = nil
+      subject.after(:suite) { |return_value| found_return_value = return_value }
+
+      subject.run_suite_with_callbacks { :fake_suite_result }
+
+      expect(found_return_value).to eq :fake_suite_result
+    end
+  end
+
+  describe 'error handling' do
+    specify 'before raises and error when passed a bogus level' do
+      expect { subject.before(:bogus) }.to raise_error ArgumentError
+    end
+
+    specify 'after raises and error when passed a bogus level' do
+      expect { subject.after(:bogus) }.to raise_error ArgumentError
+    end
+  end
+end

--- a/spec/simmer/configuration_spec.rb
+++ b/spec/simmer/configuration_spec.rb
@@ -16,6 +16,15 @@ describe Simmer::Configuration do
 
   subject { described_class.new(config, simmer_dir) }
 
+  context '#timeout_failure_retry_count' do
+    it('defaults to 0 (no retry)') { expect(subject.timeout_failure_retry_count).to eq 0 }
+
+    it 'returns the configured value' do
+      subject = described_class.new({ timeout_failure_retry_count: 42 }, simmer_dir)
+      expect(subject.timeout_failure_retry_count).to eq 42
+    end
+  end
+
   specify '#mysql_database_config resolves' do
     expect(subject.mysql_database_config).to eq('mysql_database_key' => 'mysql_database_value')
   end

--- a/spec/simmer/re_runner_spec.rb
+++ b/spec/simmer/re_runner_spec.rb
@@ -48,7 +48,7 @@ describe Simmer::ReRunner do
       subject.run
     end
 
-    it 'only runs the test three times when timeout_failure_retry_count = 2' do
+    it 'runs the test three times when timeout_failure_retry_count = 2' do
       subject = described_class.new(runner_double, out, timeout_failure_retry_count: 2)
       expect(runner_double).to receive(:run).exactly(3).times.and_return(timeout_result)
 

--- a/spec/simmer/re_runner_spec.rb
+++ b/spec/simmer/re_runner_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+require './spec/mocks/out'
+
+describe Simmer::ReRunner do
+  let(:runner_double) { double(Simmer::Runner) }
+  let(:passing_result) { Simmer::Runner::Result.new(id: :timeout, specification: :foo) }
+  let(:out) { StringIO.new }
+  let(:subject) { described_class.new(runner_double, out) }
+
+  it 'delegates to the runner' do
+    run_args = %i[foo bar]
+    expect(runner_double).to receive(:run).with(run_args).and_return(passing_result)
+    expect(runner_double).to receive(:complete)
+
+    subject.run(run_args)
+    subject.complete
+  end
+
+  it 'returns what the runner returns' do
+    expect(runner_double).to receive(:run).and_return(passing_result)
+
+    expect(subject.run).to eq passing_result
+  end
+
+  describe 'when a test fails due to a timeout' do
+    let(:timeout_result) do
+      errors = [Timeout::Error.new]
+      Simmer::Runner::Result.new(id: :timeout, specification: :foo, errors: errors)
+    end
+
+    it 'only runs a test once when timeout_failure_retry_count = 0' do
+      subject = described_class.new(runner_double, out, timeout_failure_retry_count: 0)
+      expect(runner_double).to receive(:run).once.and_return(timeout_result)
+
+      subject.run
+    end
+
+    it 'only runs the test three times when timeout_failure_retry_count = 2' do
+      subject = described_class.new(runner_double, out, timeout_failure_retry_count: 2)
+      expect(runner_double).to receive(:run).exactly(3).times.and_return(timeout_result)
+
+      subject.run
+    end
+
+    it 'stops running the test as soon as it passes' do
+      subject = described_class.new(runner_double, out, timeout_failure_retry_count: 2)
+      expect(runner_double).to receive(:run).and_return(timeout_result)
+      expect(runner_double).to receive(:run).and_return(passing_result)
+      # Note that it is not retried a second time.
+
+      subject.run
+    end
+
+    describe 'output' do
+      let(:output) { double(Simmer::Suite::OutputRouter) }
+
+      it 'announces that a rerun is occurring due to a timeout' do
+        subject = described_class.new(runner_double, output, timeout_failure_retry_count: 1)
+        expect(runner_double).to receive(:run).and_return(timeout_result)
+        expect(runner_double).to receive(:run).and_return(passing_result)
+
+        expect(output).to receive(:puts).with('Retrying due to a timeout...').once
+
+        subject.run
+      end
+    end
+  end
+end

--- a/spec/simmer/re_runner_spec.rb
+++ b/spec/simmer/re_runner_spec.rb
@@ -37,7 +37,7 @@ describe Simmer::ReRunner do
 
   describe 'when a test fails due to a timeout' do
     let(:timeout_result) do
-      errors = [Timeout::Error.new]
+      errors = [Simmer::Runner::TimeoutError.new]
       Simmer::Runner::Result.new(id: :timeout, specification: :foo, errors: errors)
     end
 

--- a/spec/simmer/runner/timeout_error_spec.rb
+++ b/spec/simmer/runner/timeout_error_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+require './spec/mocks/out'
+
+describe Simmer::Runner::TimeoutError do
+  describe 'the message' do
+    it 'is "a timeout ocurred" if there is no previous error' do
+      subject = described_class.new
+      expect(subject.message).to eq 'a timeout occurred'
+    end
+
+    it 'is the message of the error that caused it' do
+      subject = nil
+
+      begin
+        begin
+          raise 'custom message'
+        rescue StandardError
+          raise described_class
+        end
+      rescue described_class => e
+        subject = e
+      end
+
+      expect(subject.message).to eq 'custom message'
+    end
+  end
+end

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -173,7 +173,7 @@ describe Simmer do
       end
 
       it 'records the timeout error' do
-        expect(results.runner_results.first.errors).to include(/execution expired/)
+        expect(results.runner_results.first.errors).to include(Timeout::Error)
       end
 
       specify 'after each callbacks get a failing result with the timeout error' do
@@ -182,7 +182,7 @@ describe Simmer do
 
         expect(results).not_to be_passing
         expect(after_each_result).not_to be_passing
-        expect(after_each_result.errors).to include(/execution expired/)
+        expect(after_each_result.errors).to include(Timeout::Error)
       end
     end
 
@@ -238,7 +238,8 @@ describe Simmer do
           simmer_dir: simmer_dir
         )
 
-        expect(results.runner_results.first.errors).to include(/fixture missing/)
+        expect(results.runner_results.first.errors).to \
+          include(Simmer::Database::FixtureSet::FixtureMissingError)
       end
     end
   end

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -96,11 +96,11 @@ describe Simmer do
         it 'calls them in the expected order' do
           found_order = []
 
-          described_class.configure do
-            before(:suite) { found_order.push(:before_suite) }
-            before(:each) { found_order.push(:before_each) }
-            after(:each) { found_order.push(:after_each) }
-            after(:suite) { found_order.push(:after_suite) }
+          described_class.configure do |config|
+            config.before(:suite) { found_order.push(:before_suite) }
+            config.before(:each) { found_order.push(:before_each) }
+            config.after(:each) { found_order.push(:after_each) }
+            config.after(:suite) { found_order.push(:after_suite) }
           end
 
           expect(results).to be_passing
@@ -111,9 +111,9 @@ describe Simmer do
           after_each_result = nil
           after_suite_result = nil
 
-          described_class.configure do
-            after(:each) { |result| after_each_result = result }
-            after(:suite) { |result| after_suite_result = result }
+          described_class.configure do |config|
+            config.after(:each) { |result| after_each_result = result }
+            config.after(:suite) { |result| after_suite_result = result }
           end
 
           expect(results).to be_passing
@@ -143,9 +143,9 @@ describe Simmer do
         after_each_result = nil
         after_suite_result = nil
 
-        described_class.configure do
-          after(:each) { |result| after_each_result = result }
-          after(:suite) { |result| after_suite_result = result }
+        described_class.configure do |config|
+          config.after(:each) { |result| after_each_result = result }
+          config.after(:suite) { |result| after_suite_result = result }
         end
 
         expect(results).not_to be_passing
@@ -177,7 +177,7 @@ describe Simmer do
 
       specify 'after each callbacks get a failing result with the timeout error' do
         after_each_result = nil
-        described_class.configure { after(:each) { |result| after_each_result = result } }
+        described_class.configure { |c| c.after(:each) { |result| after_each_result = result } }
 
         expect(results).not_to be_passing
         expect(after_each_result).not_to be_passing

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -172,7 +172,7 @@ describe Simmer do
       end
 
       it 'records the timeout error' do
-        expect(results.runner_results.first.errors).to include(Timeout::Error)
+        expect(results.runner_results.first.errors).to include(Simmer::Runner::TimeoutError)
       end
 
       specify 'after each callbacks get a failing result with the timeout error' do
@@ -181,7 +181,7 @@ describe Simmer do
 
         expect(results).not_to be_passing
         expect(after_each_result).not_to be_passing
-        expect(after_each_result.errors).to include(Timeout::Error)
+        expect(after_each_result.errors).to include(Simmer::Runner::TimeoutError)
       end
     end
   end

--- a/spec/simmer_spec.rb
+++ b/spec/simmer_spec.rb
@@ -16,6 +16,14 @@ describe Simmer do
   let(:spoon_path) { File.join('spec', 'mocks', 'spoon') }
   let(:spoon_args) { '' }
   let(:config_path) { stage_simmer_config(spoon_path, spoon_args) }
+  let(:results) do
+    described_class.run(
+      spec_path,
+      config_path: config_path,
+      out: out,
+      simmer_dir: simmer_dir
+    )
+  end
 
   def stage_simmer_config(spoon_dir, spoon_args, timeout_in_seconds = nil)
     dest_config_dir  = File.join('tmp')
@@ -47,46 +55,18 @@ describe Simmer do
     context 'when pdi does not do anything but does not fail' do
       let(:spoon_args) { 0 }
 
-      specify 'judge determines it does not pass' do
-        results = described_class.run(
-          spec_path,
-          config_path: config_path,
-          out: out,
-          simmer_dir: simmer_dir
-        )
-
-        expect(results).not_to be_passing
-      end
+      specify('judge determines it does not pass') { expect(results).not_to be_passing }
     end
 
     context 'when pdi fails' do
       let(:spoon_args) { 1 }
 
-      it 'fails' do
-        results = described_class.run(
-          spec_path,
-          config_path: config_path,
-          out: out,
-          simmer_dir: simmer_dir
-        )
-
-        expect(results).not_to be_passing
-      end
+      it('fails') { expect(results).not_to be_passing }
     end
 
     context 'when pdi acts correctly' do
       let(:spoon_path) { File.join('spec', 'mocks', 'load_noc_list') }
       let(:spoon_args) { '' }
-
-      # TODO: extract this to the top level, if they are all the same
-      let(:results) do
-        described_class.run(
-          spec_path,
-          config_path: config_path,
-          out: out,
-          simmer_dir: simmer_dir
-        )
-      end
 
       specify 'the judge determines it to pass' do
         expect(results).to be_passing
@@ -126,14 +106,6 @@ describe Simmer do
     context 'when pdi acts correctly but judge fails on output assert' do
       let(:spoon_path) { File.join('spec', 'mocks', 'load_noc_list_bad_output') }
       let(:spoon_args) { '' }
-      let(:results) do
-        described_class.run(
-          spec_path,
-          config_path: config_path,
-          out: out,
-          simmer_dir: simmer_dir
-        )
-      end
 
       specify 'fails' do
         expect(results).not_to be_passing
@@ -157,15 +129,6 @@ describe Simmer do
     context 'when pdi times out' do
       let(:spoon_args) { [0, 10] }
       let(:config_path) { stage_simmer_config(spoon_path, spoon_args, 1) }
-
-      let(:results) do
-        described_class.run(
-          spec_path,
-          config_path: config_path,
-          out: out,
-          simmer_dir: simmer_dir
-        )
-      end
 
       it 'fails' do
         expect(results).not_to be_passing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,11 @@ unless ENV['DISABLE_SIMPLECOV'] == 'true'
   end
 end
 
+RSpec.configure do |c|
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
+end
+
 require './lib/simmer'
 
 def fixture_path(*filename)

--- a/spec/yaml_config_helpers.rb
+++ b/spec/yaml_config_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+require 'yaml'
+
+def yaml_read(*filename)
+  YAML.safe_load(File.read(File.join(*filename)), [], [], true)
+end
+
+def simmer_config
+  yaml_read('spec', 'config', 'simmer.yaml')
+end


### PR DESCRIPTION
This adds two new features auto retry on timeout and lifecycle hooks. These two features are independent but when paired together the hooks allow for applications to clean up global state before a test is retried. This also extracts a Simmer::Bootstrap class from the Simmer module. I was continually running up against Rubocop module length limits so this class extraction should improve this going forward. As part of this, I was also able to increase test coverage to 100%.